### PR TITLE
Fixed bug that was not changing directories before executing command.

### DIFF
--- a/DataProcessingTools/levels.py
+++ b/DataProcessingTools/levels.py
@@ -3,6 +3,7 @@ import glob
 import re
 import json
 import numpy as np
+from . import misc
 
 levels = []
 level_patterns_s = []
@@ -190,10 +191,11 @@ def processLevel(level, cmd="", normalize=True):
 
     """
     dirs = get_level_dirs(level)
-    if normalize:
-        dirs = [normpath(d) for d in dirs]
     data = []
     for d in dirs:
-        exec(cmd)
+        with misc.CWD(d):
+            exec(cmd)
 
+    if normalize:
+        dirs = [normpath(d) for d in dirs]
     return dirs, data


### PR DESCRIPTION
Fixed bug that was not changing directories before executing command.

Also fixed bug that was calling the normpath function on directories before they were used, causing problems changing directories (e.g. if we were in the array01 directory, directories should be channel002, channel003, etc., but normpath made them into picasso/20181105/session01/array01/channel002, which could not be found).