### PR TITLE
Removes 'complete example' from README'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,42 +47,6 @@ class DirFiles(DPT.DPObject):
             self.setidx = [0 for i in range(dnum)] 
 ```
 
-### A complete example
-Here is an example of how to compute raster and psth for a list for a list of
-cells and step through plots of both using PanGUI
-
-```python
-import DataProcessingTools as DPT
-import numpy as np
-import os
-import PanGUI
-
-# change this to wherever you keep the data hierarchy
-datadir = os.path.expanduser("~/Documents/workingMemory")
-
-# get all the cells for one session
-with DPT.misc.CWD(os.path.join(datadir, "Whiskey/20200106/session02")):
-    cells = DPT.levels.get_level_dirs("cell")
-
-# gather rasters and PSTH for these cells, for the error trials
-bins = np.arange(-300, 1000.0, 10)
-with DPT.misc.CWD(cells[0]):
-    raster = DPT.raster.Raster(-300.0, 1000.0, "stimulus1", "reward_on", "stimulus1",
-                               redoLevel=1, saveLevel=0)
-    psth = DPT.psth.PSTH(bins, 10, trialEvent="stimulus1", sortBy="stimulus1", trialType="reward_on",
-                         redoLevel=1, saveLevel=0)
-for cell in cells[1:]:
-    with DPT.misc.CWD(cell):
-        praster = DPT.raster.Raster(-300.0, 1000.0, "stimulus1", "reward_on", "stimulus1",
-                                    redoLevel=1, saveLevel=0)
-        raster.append(praster)
-        ppsth = DPT.psth.PSTH(bins, 10, trialEvent="stimulus1", sortBy="stimulus1", trialType="reward_on",
-                              redoLevel=1, saveLevel=0)
-        psth.append(ppsth)
-
-app = PanGUI.create_window([raster, psth], cols=1, indexer="cell")
-```
-
 ## Custom hierarchy
 
 It also possible to customize the hierarchy that DPT understands. This is done with a JSON coded config file. This is what 


### PR DESCRIPTION
This removes the parts of the README that referred to code that now lives in https://github.com/grero/NeuralProcessingTools